### PR TITLE
Use ConfigFactoryOverrideInterface to override the config storage

### DIFF
--- a/acquia_pendo.info.yml
+++ b/acquia_pendo.info.yml
@@ -2,7 +2,7 @@ name: 'Acquia Pendo'
 type: module
 description: 'Pendo integration for Acquia products.'
 core: 8.x
+core_version_requirement: '^8 || ^9'
 package: 'Web Services'
-
 dependencies:
   - drupal:pendo

--- a/acquia_pendo.module
+++ b/acquia_pendo.module
@@ -34,9 +34,10 @@ function acquia_pendo_preprocess_html(&$variables) {
  * Implements hook_form_FORM_ID_alter().
  */
 function acquia_pendo_form_pendo_admin_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
-  if (getenv('AH_PENDO_KEY') !== FALSE) {
+  if ($ahPendoApiKey = getenv('AH_PENDO_KEY')) {
     $form['api_key']['#disabled'] = TRUE;
     $form['api_key']['#prefix'] = t('This application is being run in an Acquia environment. The Acquia Pendo API key will be used automatically.');
-    $form['api_key']['#value'] = '';
+    $form['api_key']['#value'] = $ahPendoApiKey;
+    $form['actions']['submit']['#disabled'] = TRUE;
   }
 }

--- a/acquia_pendo.services.yml
+++ b/acquia_pendo.services.yml
@@ -1,0 +1,5 @@
+services:
+  acquia_pendo_ah_key.overrider:
+    class: 'Drupal\acquia_pendo\Config\AcquiaPendoAhKeyOverrider'
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+  "name": "drupal/acquia_pendo",
+  "type": "drupal-module",
+  "description": "Pendo integration for Acquia products.",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "drupal/pendo": "^1.0"
+  },
+  "minimum-stability": "dev"
+}

--- a/src/Config/AcquiaPendoAhKeyOverrider.php
+++ b/src/Config/AcquiaPendoAhKeyOverrider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\acquia_pendo\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Override the Pendo API key configuration if the AH_PENDO_KEY environment
+ * variable is set. Acquia Cloud Hosting automatically sets the AH_PENDO_KEY
+ * environment variable.
+ */
+class AcquiaPendoAhKeyOverrider implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array('pendo.settings', $names)) {
+      if ($ahPendoApiKey = getenv('AH_PENDO_KEY')) {
+        $overrides['pendo.settings'] = ['api_key' => $ahPendoApiKey];
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'AcquiaPendoAhKeyOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+}


### PR DESCRIPTION
It seems like this module is doing a bit more than described in the ticket, so I think it's best to extend it and just have Lightning include it.

This PR uses `ConfigFactoryOverrideInterface` to override the the value if the `AH_PENDO_KEY` env variable is set. That way, it won't mess with any config exports or imports.

It also adds a dependency on the `drupal/pendo` module and allows it to be installed on Drupal 9. Once we merge this, I think we should create a project for it on Drupal.org and make it a soft dependency of Lightning Core and installed by the profile.